### PR TITLE
Fix import error

### DIFF
--- a/depedit/__init__.py
+++ b/depedit/__init__.py
@@ -1,2 +1,2 @@
 ## DepEdit init ##
-from depedit import DepEdit
+from .depedit import DepEdit


### PR DESCRIPTION
Without the leading ".", this tries to import from the `depedit` *package*, which we are currently in the `__init__.py` of.